### PR TITLE
Add option to specify basePath

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  basePath: process.env.BASE_PATH || "",
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
This uses the Next.js [basePath config](https://nextjs.org/docs/api-reference/next.config.js/basepath) to enable deploying the demo to a subpath under our demos domain, while keeping the local demo copy untouched (i.e. localhost:3000).

For demos that require backend calls, there are two extra additions required:

_next.config.js_
```
...
env: {
  BASE_PATH: process.env.BASE_PATH || "",
}
```

_In the frontend_
```js
// Pre-pend any and all /api/... calls with the base path
await fetch(`${process.env.BASE_PATH}/api/<endpoint>`)
```